### PR TITLE
put brew install mutt at end, in case it fails

### DIFF
--- a/mutt/installMuttForGmailOrApps.sh
+++ b/mutt/installMuttForGmailOrApps.sh
@@ -36,17 +36,6 @@ if [ -e $muttdirExpanded ]; then
 fi
 
 echo
-echo '... Attempting mutt install'
-brew install mutt
-if [ $? -ne 0 ]; then
-	echo -e 'brew mutt install: \033[31mfailed\033[0m'
-	echo 'Exiting'
-	exit
-else
-	echo 'mutt install: \033[32mdone\033[0m'
-fi
-
-echo
 echo "... Setting $muttrcFile"
 { # See https://stackoverflow.com/a/51113160/1071459
 	echo "set imap_user = \"$userdomain\""
@@ -70,3 +59,14 @@ echo "... Creating directories in $muttdir"
 mkdir -p $muttdirExpanded/cache/headers
 mkdir -p $muttdirExpanded/cache/bodies
 mkdir -p $muttdirExpanded/certificates
+
+echo
+echo '... Attempting mutt install'
+brew install mutt
+if [ $? -ne 0 ]; then
+	echo -e 'brew mutt install: \033[31mfailed\033[0m'
+	echo 'Exiting'
+	exit
+else
+	echo 'mutt install: \033[32mdone\033[0m'
+fi


### PR DESCRIPTION
This was the failure I got, suggesting that I add some stuff to my spoolfile in .muttrc, but if this script continued, it would have setup a .muttrc, so I could see a good example of how to set variables in the .muttrc file 👍 

```
... Attempting mutt install
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).
==> New Formulae
baidupcs-go         ensmallen           git-remote-gcrypt   nebula
blis                ffuf                hpack               node-sass
corral              fileicon            libffcall           okteto
crc                 findent             mavsdk              python@3.8
docker-slim         flint               meilisearch         uni
==> Updated Formulae
glib ✔                     ghq                        node@8
gts ✔                      git-annex                  norm
netpbm ✔                   git-extras                 now-cli
node ✔                     gitlab-runner              nushell
python@2 ✔                 gitmoji                    nvm
ruby-build ✔               gitversion                 ocrmypdf
activemq                   gleam                      osslsigncode
aliyun-cli                 glew                       overmind
allure                     glooctl                    packer
ammonite-repl              gloox                      paket
angular-cli                gmic                       pandoc
appscale-tools             gmsh                       pdf-redact-tools
arduino-cli                gnunet                     peco
asdf                       go                         pgcli
ask-cli                    gocr                       phoronix-test-suite
aspectj                    godep                      php
astrometry-net             golang-migrate             php@7.2
audacious                  grafana                    php@7.3
aws-cdk                    grakn                      phpstan
aws-sdk-cpp                groonga                    plantuml
azure-cli                  grpc                       pnpm
babel                      h3                         prestosql
bashdb                     haxe                       pspg
bazel                      helm                       pulumi
bazelisk                   helmfile                   pumba
bedtools                   homeassistant-cli          pyinvoke
berglas                    howdoi                     qbs
binaryen                   hstr                       qpid-proton
bind                       hugo                       qt
bindfs                     i2p                        radare2
bison                      imagemagick                rav1e
bitwise                    imagemagick@6              re2c
borgmatic                  imlib2                     rebar3
bundletool                 iozone                     recon-ng
c-blosc                    istioctl                   remctl
calicoctl                  ivy                        rethinkdb
cargo-c                    janet                      riemann
cargo-completion           javacc                     rsnapshot
cassandra@2.1              jenkins                    rust
cassandra@2.2              jenkins-lts                rustup-init
cfn-lint                   jfrog-cli-go               sceptre
cimg                       jhipster                   scons
citus                      jupyterlab                 scrcpy
cmake                      k6                         sdb
contentful-cli             khard                      serverless
convox                     kibana                     shfmt
cppcheck                   kompose                    skaffold
cppunit                    krb5                       snakemake
crc32c                     kustomize                  snapcraft
crystal                    launch_socket_server       sonarqube
csvq                       libde265                   sqlcipher
cups                       libebml                    ssh-vault
dashing                    libedit                    sslyze
deno                       libev                      sstp-client
deployer                   libgit2                    starship
detekt                     libgr                      stolon
devspace                   libheif                    stress-ng
dhall-bash                 libical                    subliminal
django-completion          libmagic                   swiftformat
dlib                       libpq                      tectonic
dnscrypt-proxy             libpulsar                  telegraf
docfx                      librdkafka                 teleport
duck                       libsixel                   termshark
duplicity                  libvpx                     terraform-docs
easyengine                 linkerd                    terragrunt
embulk                     lmod                       terrahub
ephemeralpg                makensis                   tflint
erlang                     mame                       tomcat@7
eslint                     mariadb-connector-c        vice
exploitdb                  mesa                       vulkan-headers
fastlane                   mesos                      weaver
fceux                      micronaut                  webpack
file-formula               minetest                   wireguard-tools
fio                        minikube                   wolfssl
firebase-cli               mitmproxy                  wtf
fluxctl                    monetdb                    wtfutil
fmt                        mongo-c-driver             xmake
fonttools                  monolith                   xmrig
freeciv                    mutt                       xrootd
frugal                     navi                       yadm
futhark                    nethack                    yamllint
fzf                        newsboat                   zeek
gatsby-cli                 node@10
gauche                     node@12
==> Deleted Formulae
apm-server          gost                iron-functions      sshconfigfs
boost-python@1.59   headphones          logentries          warp

==> Installing dependencies for mutt: adns, gmp, libidn2, libtasn1, nettle, p11-kit, libevent, unbound, gnutls, libgpg-error, libassuan, libgcrypt, libksba, libusb, npth, pinentry, gnupg, gpgme and tokyo-cabinet
==> Installing mutt dependency: adns
==> Downloading https://homebrew.bintray.com/bottles/adns-1.5.1.mojave.bottle.ta
==> Downloading from https://akamai.bintray.com/1a/1a067d7acebfc1733c3b035ca51c7
######################################################################## 100.0%
==> Pouring adns-1.5.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/adns/1.5.1: 14 files, 597.5KB
==> Installing mutt dependency: gmp
==> Downloading https://homebrew.bintray.com/bottles/gmp-6.1.2_2.mojave.bottle.1
==> Downloading from https://akamai.bintray.com/84/84f74594086bccc53bdb141f4d06d
######################################################################## 100.0%
==> Pouring gmp-6.1.2_2.mojave.bottle.1.tar.gz
🍺  /usr/local/Cellar/gmp/6.1.2_2: 18 files, 3.1MB
==> Installing mutt dependency: libidn2
==> Downloading https://homebrew.bintray.com/bottles/libidn2-2.3.0.mojave.bottle
==> Downloading from https://akamai.bintray.com/d5/d56e7ff347b0a4c2c433cd44564df
######################################################################## 100.0%
==> Pouring libidn2-2.3.0.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libidn2/2.3.0: 70 files, 719.7KB
==> Installing mutt dependency: libtasn1
==> Downloading https://homebrew.bintray.com/bottles/libtasn1-4.15.0.mojave.bott
######################################################################## 100.0%
==> Pouring libtasn1-4.15.0.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libtasn1/4.15.0: 60 files, 392.9KB
==> Installing mutt dependency: nettle
==> Downloading https://homebrew.bintray.com/bottles/nettle-3.4.1.mojave.bottle.
==> Downloading from https://akamai.bintray.com/9e/9e7f78a4cc96ca57f75ca1d37cc12
######################################################################## 100.0%
==> Pouring nettle-3.4.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/nettle/3.4.1: 85 files, 2MB
==> Installing mutt dependency: p11-kit
==> Downloading https://homebrew.bintray.com/bottles/p11-kit-0.23.18.1.mojave.bo
==> Downloading from https://akamai.bintray.com/f1/f199520dd64b5a625c5017831de90
######################################################################## 100.0%
==> Pouring p11-kit-0.23.18.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/p11-kit/0.23.18.1: 63 files, 2.9MB
==> Installing mutt dependency: libevent
==> Downloading https://homebrew.bintray.com/bottles/libevent-2.1.11_1.mojave.bo
==> Downloading from https://akamai.bintray.com/1e/1e14fc34baae0b65cac6d7c75bc5e
######################################################################## 100.0%
==> Pouring libevent-2.1.11_1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libevent/2.1.11_1: 1,063 files, 5MB
==> Installing mutt dependency: unbound
==> Downloading https://homebrew.bintray.com/bottles/unbound-1.9.6.mojave.bottle
==> Downloading from https://akamai.bintray.com/f6/f6ebf1d706a3c8b2b8d955757ead2
######################################################################## 100.0%
==> Pouring unbound-1.9.6.mojave.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink sbin/unbound
/usr/local/sbin is not writable.

You can try again using:
  brew link unbound
==> Caveats
To have launchd start unbound now and restart at startup:
  sudo brew services start unbound
==> Summary
🍺  /usr/local/Cellar/unbound/1.9.6: 57 files, 4.8MB
==> Installing mutt dependency: gnutls
==> Downloading https://homebrew.bintray.com/bottles/gnutls-3.6.11.1.mojave.bott
==> Downloading from https://akamai.bintray.com/ee/ee8df35a8efcb0595f454d980da7d
######################################################################## 100.0%
==> Pouring gnutls-3.6.11.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/gnutls/3.6.11.1: 1,229 files, 10MB
==> Installing mutt dependency: libgpg-error
==> Downloading https://homebrew.bintray.com/bottles/libgpg-error-1.36.mojave.bo
==> Downloading from https://akamai.bintray.com/a7/a708445b7304f711ed41bbf95f5cc
######################################################################## 100.0%
==> Pouring libgpg-error-1.36.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libgpg-error/1.36: 26 files, 856KB
==> Installing mutt dependency: libassuan
==> Downloading https://homebrew.bintray.com/bottles/libassuan-2.5.3.mojave.bott
######################################################################## 100.0%
==> Pouring libassuan-2.5.3.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libassuan/2.5.3: 16 files, 444.2KB
==> Installing mutt dependency: libgcrypt
==> Downloading https://homebrew.bintray.com/bottles/libgcrypt-1.8.5.mojave.bott
==> Downloading from https://akamai.bintray.com/d9/d983dca1f56d0177d4ecd6ea27524
######################################################################## 100.0%
==> Pouring libgcrypt-1.8.5.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libgcrypt/1.8.5: 22 files, 2.6MB
==> Installing mutt dependency: libksba
==> Downloading https://homebrew.bintray.com/bottles/libksba-1.3.5.mojave.bottle
######################################################################## 100.0%
==> Pouring libksba-1.3.5.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libksba/1.3.5: 14 files, 344.2KB
==> Installing mutt dependency: libusb
==> Downloading https://homebrew.bintray.com/bottles/libusb-1.0.23.mojave.bottle
######################################################################## 100.0%
==> Pouring libusb-1.0.23.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libusb/1.0.23: 29 files, 524.8KB
==> Installing mutt dependency: npth
==> Downloading https://homebrew.bintray.com/bottles/npth-1.6.mojave.bottle.tar.
######################################################################## 100.0%
==> Pouring npth-1.6.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/npth/1.6: 11 files, 71.7KB
==> Installing mutt dependency: pinentry
==> Downloading https://homebrew.bintray.com/bottles/pinentry-1.1.0_1.mojave.bot
######################################################################## 100.0%
==> Pouring pinentry-1.1.0_1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/pinentry/1.1.0_1: 12 files, 263.9KB
==> Installing mutt dependency: gnupg
==> Downloading https://homebrew.bintray.com/bottles/gnupg-2.2.19.mojave.bottle.
==> Downloading from https://akamai.bintray.com/5e/5e23d28a490125c271558817155b8
######################################################################## 100.0%
==> Pouring gnupg-2.2.19.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/gnupg/2.2.19: 134 files, 11MB
==> Installing mutt dependency: gpgme
==> Downloading https://homebrew.bintray.com/bottles/gpgme-1.13.1.mojave.bottle.
==> Downloading from https://akamai.bintray.com/2a/2a771556a334f9ad4603e83db53cb
######################################################################## 100.0%
==> Pouring gpgme-1.13.1.mojave.bottle.1.tar.gz
🍺  /usr/local/Cellar/gpgme/1.13.1: 128 files, 4.8MB
==> Installing mutt dependency: tokyo-cabinet
==> Downloading https://homebrew.bintray.com/bottles/tokyo-cabinet-1.4.48.mojave
==> Downloading from https://akamai.bintray.com/dd/dd723c7394954fe354044bbd6bbea
######################################################################## 100.0%
==> Pouring tokyo-cabinet-1.4.48.mojave.bottle.1.tar.gz
🍺  /usr/local/Cellar/tokyo-cabinet/1.4.48: 80 files, 4MB
==> Installing mutt
==> Downloading https://homebrew.bintray.com/bottles/mutt-1.13.1.mojave.bottle.t
==> Downloading from https://akamai.bintray.com/e3/e3a4fff34be701f8a26d60a2b9b06
######################################################################## 100.0%
==> Pouring mutt-1.13.1.mojave.bottle.tar.gz
==> Caveats
mutt_dotlock(1) has been installed, but does not have the permissions lock
spool files in /var/mail. To grant the necessary permissions, run

  sudo chgrp mail /usr/local/opt/mutt/bin/mutt_dotlock
  sudo chmod g+s /usr/local/opt/mutt/bin/mutt_dotlock

Alternatively, you may configure `spoolfile` in your .muttrc to a file inside
your home directory.
==> Summary
🍺  /usr/local/Cellar/mutt/1.13.1: 123 files, 9.4MB
==> Caveats
==> unbound
To have launchd start unbound now and restart at startup:
  sudo brew services start unbound
==> mutt
mutt_dotlock(1) has been installed, but does not have the permissions lock
spool files in /var/mail. To grant the necessary permissions, run

  sudo chgrp mail /usr/local/opt/mutt/bin/mutt_dotlock
  sudo chmod g+s /usr/local/opt/mutt/bin/mutt_dotlock

Alternatively, you may configure `spoolfile` in your .muttrc to a file inside
your home directory.
-e brew mutt install: failed
Exiting
```